### PR TITLE
Rails 5.1 support

### DIFF
--- a/lib/require_reloader.rb
+++ b/lib/require_reloader.rb
@@ -46,7 +46,7 @@ module RequireReloader
 
         # based on Tim Cardenas's solution:
         # http://timcardenas.com/automatically-reload-gems-in-rails-327-on-eve
-        ActionDispatch::Callbacks.to_prepare do
+        helper.to_prepare do
           if opts[:module_name]
             helper.remove_module_if_defined(opts[:module_name])
           else

--- a/lib/require_reloader/helper.rb
+++ b/lib/require_reloader/helper.rb
@@ -79,6 +79,13 @@ module RequireReloader
       str.split("_").map{|token| token.capitalize }.join("")
     end
 
+    def to_prepare(&block)
+      if Rails::VERSION::MAJOR == 5
+        ActiveSupport::Reloader.to_prepare(&block)
+      else
+        ActionDispatch::Callbacks.to_prepare(&block)
+      end
+    end
   end
 
 end


### PR DESCRIPTION
`ActionDispatch::Callbacks.to_prepare` is removed in Rails 5.1