### PR TITLE
Delete files only from watchable directory

### DIFF
--- a/lib/require_reloader.rb
+++ b/lib/require_reloader.rb
@@ -52,8 +52,11 @@ module RequireReloader
           else
             helper.remove_gem_module_if_defined(gem)
           end
-          $".delete_if {|s| s.include?(gem)}
+
+          $".delete_if {|s| s.include?(watchable_dir)}
+
           require gem
+
           opts[:callback].call(gem) if opts[:callback]
         end
       end


### PR DESCRIPTION
Check by gem name is not correct it can cause errors.
For example, If the gem name for any reason already exists in the path name or the gem name is the same as the gemset name:

```
# .ruby-gemset
awesome_gem_name
```
Now all paths contain this name including not local gems:

```
...@awesome_gem_name/gems/rails...
```