### PR TITLE
enable to load gem with dashes

### DIFF
--- a/lib/require_reloader/version.rb
+++ b/lib/require_reloader/version.rb
@@ -1,3 +1,3 @@
 module RequireReloader
-  VERSION = "0.2.1"
+  VERSION = "0.2.2"
 end


### PR DESCRIPTION
Closes #9 
This PR resolve the issue.

`RequireReloader.require` method work like to follow.

When a gem with dashes is specified to watch...
1. At first try `require` a ruby file whose name is same as gem's name
2. If file is not found, then try `require` one that is replaced dash with a slash
3. If it is still not found, an error will occur

This feature is same as `Bundler.require`.
https://github.com/rubygems/rubygems/blob/a753447de8fb92dad30e927656984aa2b7765f3d/bundler/lib/bundler/runtime.rb#L54-L96
